### PR TITLE
Fix not display term meta in loop

### DIFF
--- a/src/Traits/Archive.php
+++ b/src/Traits/Archive.php
@@ -30,13 +30,35 @@ trait Archive {
 		return $groups;
 	}
 
+	/**
+	 * Get the current term ID.
+	 * Get from $wp_query->loop_term - a global that Elementor Pro sets (see
+	 * ElementorPro\Modules\LoopBuilder\Skins\Skin_Loop_Taxonomy_Base::render_loop_content()).
+	 *
+	 * get_queried_object_id() only works on a real single term archive page
+	 */
+	private function get_current_term_id( $taxonomy ) {
+		global $wp_query;
+
+		if (
+			isset( $wp_query->loop_term )
+			&& is_object( $wp_query->loop_term )
+			&& isset( $wp_query->loop_term->term_id )
+			&& ( empty( $taxonomy ) || $wp_query->loop_term->taxonomy === $taxonomy )
+		) {
+			return (int) $wp_query->loop_term->term_id;
+		}
+
+		return get_queried_object_id();
+	}
+
 	private function handle_get_value() {
 		$key = $this->get_settings( 'key' );
 		if ( ! $key ) {
 			return null;
 		}
 		list( $taxonomy, $field_id ) = explode( ':', $key );
-		return rwmb_meta( $field_id, [ 'object_type' => 'term' ], get_queried_object_id() );
+		return rwmb_meta( $field_id, [ 'object_type' => 'term' ], $this->get_current_term_id( $taxonomy ) );
 	}
 
 	private function the_value() {
@@ -45,7 +67,7 @@ trait Archive {
 			return null;
 		}
 		list( $taxonomy, $field_id ) = explode( ':', $key );
-		rwmb_the_value( $field_id, [ 'object_type' => 'term' ], get_queried_object_id() );
+		rwmb_the_value( $field_id, [ 'object_type' => 'term' ], $this->get_current_term_id( $taxonomy ) );
 		if ( ! is_singular() ) {
 			return null;
 		}


### PR DESCRIPTION
https://app.asana.com/1/11768486970802/inbox/1200179452020373/item/1213920641760966/story/1216369550553977
Elementor có set 1 biến global cho loop term ở `elementor-pro/modulesloop-builder/skins/skin-loop-taxonomy-base.php` hàm 

```
protected function render_loop_content( $terms, $template_id ) {
    global $wp_query;
    foreach ( $terms as $term ) {
        $wp_query->loop_term = $term;   // ← term hiện tại của vòng lặp
        $this->render_post();
        $wp_query->loop_term = null;    // ← reset sau mỗi item
    }
}
```

Elementor và ACF lấy data term qua biến này.